### PR TITLE
Docker Build & Push ワークフロー追加

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,61 @@
+name: Docker Build & Push
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/mock-openid-provider
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha,prefix={{branch}}-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./src/MockOpenIdProvider/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            GITHUB_TOKEN=${{ secrets.ORG_PAT }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## 概要

main ブランチへのマージ時に Docker イメージを自動ビルド・プッシュするワークフローを追加します。

## 変更内容

- `.github/workflows/docker-build.yml` 追加
  - main ブランチへの push 時に自動実行
  - タグ push 時にも自動実行（`v*` パターン）
  - 手動実行（workflow_dispatch）にも対応
  - GitHub Container Registry へのプッシュ
  - タグ付け戦略:
    - `latest`: main ブランチの最新コミット
    - `main-<sha>`: main ブランチのコミット SHA
    - `v1.2.3`, `v1.2`, `v1`: セマンティックバージョニング（タグ push 時）
  - GitHub Actions キャッシュ活用（ビルド高速化）

## トリガー

- **push**: main ブランチへの push
- **tags**: `v*` パターンのタグ push
- **workflow_dispatch**: 手動実行

## 使用する Secret

- `ORG_PAT`: GitHub Packages 認証用（NuGet パッケージ取得）
- `GITHUB_TOKEN`: GitHub Container Registry 認証用（自動提供）

## 関連

- Phase 6.2: Docker Build & Push ワークフローの構築