### PR TITLE
feat: ヘルスチェックエンドポイント (/healthz) の実装

### DIFF
--- a/src/MockOpenIdProvider/MockOpenIdProvider.csproj
+++ b/src/MockOpenIdProvider/MockOpenIdProvider.csproj
@@ -21,6 +21,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="9.0.9" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.4" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.2" />


### PR DESCRIPTION
## 概要

Azure Container Apps のヘルスプローブに対応するため、Kubernetes 標準の `/healthz` エンドポイントを実装しました。

Fixes #8

## 実装内容

### 追加したエンドポイント

1. **`/healthz`** - 全体的なヘルスチェック
   - データベース接続を含む全てのヘルスチェック
   - Liveness Probe として使用可能

2. **`/healthz/ready`** - Readiness Probe
   - データベース接続が必須
   - トラフィック受け入れ準備の確認

3. **`/healthz/live`** - Liveness Probe
   - プロセス生存確認のみ
   - データベースチェックは不要

### 変更ファイル

- `src/MockOpenIdProvider/MockOpenIdProvider.csproj`
  - `Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore` パッケージを追加

- `src/MockOpenIdProvider/Program.cs`
  - ヘルスチェックサービスの登録
  - 3つのヘルスチェックエンドポイントの設定

## テスト

- ✅ ローカルビルド成功
- ✅ 全ユニットテスト合格（11/11）

## 確認方法

```bash
# ローカル環境
curl https://localhost:9091/healthz
curl https://localhost:9091/healthz/ready
curl https://localhost:9091/healthz/live
```

## 次のステップ

1. この PR がマージされ、Docker イメージがビルドされたら、Azure Container Apps のヘルスプローブを設定（ecauth-infrastructure リポジトリ）
2. Phase 6.3: Azure デプロイワークフローの実装

🤖 Generated with [Claude Code](https://claude.com/claude-code)