### PR TITLE
fix: dotnet-ef ツールの PATH を設定

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -44,7 +44,9 @@ jobs:
           --store-password-in-clear-text
 
     - name: Install EF Core tools
-      run: dotnet tool install --global dotnet-ef
+      run: |
+        dotnet tool install --global dotnet-ef
+        echo "$HOME/.dotnet/tools" >> $GITHUB_PATH
 
     - name: Restore dependencies
       run: dotnet restore src/MockOpenIdProvider/MockOpenIdProvider.csproj


### PR DESCRIPTION
## Summary

- GitHub Actions で `dotnet-ef` コマンドが見つからない問題を修正
- `$HOME/.dotnet/tools` を `GITHUB_PATH` に追加

## 背景

PR #13 マージ後に実行された migrate ワークフローで、以下のエラーが発生：

```
Run "dotnet tool restore" to make the "dotnet-ef" command available.
```

グローバルにインストールした `dotnet-ef` ツールの PATH が設定されていなかったため。

## Test plan

- [ ] migrate ワークフローが正常に実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)