### PR TITLE
fix: dotnet-ef をローカルツールとして復元するよう変更

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,10 +3,11 @@
   "isRoot": true,
   "tools": {
     "dotnet-ef": {
-      "version": "9.0.0",
+      "version": "9.0.11",
       "commands": [
         "dotnet-ef"
-      ]
+      ],
+      "rollForward": false
     }
   }
 }

--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -43,10 +43,8 @@ jobs:
           --password ${{ secrets.ORG_PAT }} \
           --store-password-in-clear-text
 
-    - name: Install EF Core tools
-      run: |
-        dotnet tool install --global dotnet-ef
-        echo "$HOME/.dotnet/tools" >> $GITHUB_PATH
+    - name: Restore EF Core tools
+      run: dotnet tool restore
 
     - name: Restore dependencies
       run: dotnet restore src/MockOpenIdProvider/MockOpenIdProvider.csproj


### PR DESCRIPTION
## Summary

- `.config/dotnet-tools.json` の `dotnet-ef` バージョンを 9.0.0 → 9.0.11 に更新
- `migrate.yml` でグローバルインストールから `dotnet tool restore` に変更

## 背景

PR #14 マージ後も migrate ワークフローで `dotnet-ef` が見つからないエラーが発生。
`$GITHUB_PATH` への追加では次のステップで反映されるはずだが、実際には動作しなかった。

## 解決策

ローカルツールマニフェスト（`.config/dotnet-tools.json`）を使用して `dotnet tool restore` で復元する方式に変更。

**メリット**:
- PATH の問題を回避
- ツールバージョンをリポジトリで管理
- プロジェクトの EF Core バージョン（9.0.x）と一致

## Test plan

- [x] migrate ワークフローが正常に実行されることを確認
- [x] `dotnet ef database update` が成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)