### PR TITLE
ci: add staging dummy env vars to dev migration step

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -67,6 +67,13 @@ jobs:
         MOCK_IDP_FEDERATE_CLIENT_SECRET: ${{ secrets.MOCK_IDP_FEDERATE_CLIENT_SECRET || 'federate-client-secret' }}
         MOCK_IDP_FEDERATE_CLIENT_NAME: ${{ vars.MOCK_IDP_FEDERATE_CLIENT_NAME || 'FederateClient' }}
         MOCK_IDP_FEDERATE_USER_EMAIL: ${{ vars.MOCK_IDP_FEDERATE_USER_EMAIL || 'federateuser@example.com' }}
+        # Staging 用ダミー値（dev 環境のマイグレーション実行に必要）
+        MOCKIDP_STAGING_CLIENT_ID: staging-dummy-clientid
+        MOCKIDP_STAGING_CLIENT_SECRET: staging-dummy-secret
+        MOCKIDP_STAGING_CLIENT_NAME: StagingDummyClient
+        MOCKIDP_STAGING_REDIRECT_URI: https://localhost:8081/auth/callback
+        MOCKIDP_STAGING_USER_EMAIL: staging-dummy@example.com
+        MOCKIDP_STAGING_USER_PASSWORD: dummy-password
       run: |
         cd src/MockOpenIdProvider
         dotnet ef database update --verbose


### PR DESCRIPTION
## Summary

- Add dummy `MOCKIDP_STAGING_*` environment variables to the dev migration step in `migrate.yml`
- The `InsertStagingClientAndUser` migration requires these environment variables even when running in dev environment

## Background

After merging PR #19, the migration workflow failed because the dev environment step was missing the staging environment variables required by the new migration.

Error:
```
System.InvalidOperationException: MOCKIDP_STAGING_CLIENT_ID is required
```

## Changes

- Added dummy staging environment variables to the "Run database migrations (dev)" step

🤖 Generated with [Claude Code](https://claude.com/claude-code)