### PR TITLE
feat: .NET 10 へ移行し EcAuth.IdpUtilities 2.0.0 を参照

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: '9.0.x'
+        dotnet-version: '10.0.x'
 
     - name: Add GitHub Packages source with credentials
       run: |

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Set up .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '9.0.x'
+          dotnet-version: '10.0.x'
 
       - name: Add GitHub Packages source with credentials
         run: |

--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 env:
-  DOTNET_VERSION: '9.0.x'
+  DOTNET_VERSION: '10.0.x'
 
 jobs:
   migrate:

--- a/src/MockOpenIdProvider/Dockerfile
+++ b/src/MockOpenIdProvider/Dockerfile
@@ -1,13 +1,13 @@
 # デバッグ コンテナーをカスタマイズする方法と、Visual Studio がこの Dockerfile を使用してより高速なデバッグのためにイメージをビルドする方法については、https://aka.ms/customizecontainer をご覧ください。
 
 # このステージは、VS から高速モードで実行するときに使用されます (デバッグ構成の既定値)
-FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
 WORKDIR /app
 EXPOSE 8080
 EXPOSE 8081
 
 # 開発環境用の証明書設定
-FROM mcr.microsoft.com/dotnet/sdk:9.0 AS dev-certs
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS dev-certs
 RUN mkdir -p /https && \
     dotnet dev-certs https -ep /https/aspnetapp.pfx -p changeit
 
@@ -17,7 +17,7 @@ USER $APP_UID
 
 
 # このステージは、サービス プロジェクトのビルドに使用されます
-FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG BUILD_CONFIGURATION=Release
 ARG GITHUB_TOKEN
 WORKDIR /src
@@ -59,7 +59,7 @@ RUN mkdir -p /certs
 RUN mkcert -cert-file /certs/localhost.crt -key-file /certs/localhost.key localhost 127.0.0.1 ::1
 
 # Linux環境用: 証明書をPFX形式に変換するステージ
-FROM mcr.microsoft.com/dotnet/sdk:9.0 AS pfx-converter
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS pfx-converter
 WORKDIR /certs
 COPY --from=cert-generator /certs/localhost.crt /certs/localhost.key ./
 RUN apt-get update && apt-get install -y openssl && \

--- a/src/MockOpenIdProvider/MockOpenIdProvider.csproj
+++ b/src/MockOpenIdProvider/MockOpenIdProvider.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.6" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="EcAuth.IdpUtilities" Version="1.1.0" />
+    <PackageReference Include="EcAuth.IdpUtilities" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Migrations\" />

--- a/src/MockOpenIdProvider/MockOpenIdProvider.csproj
+++ b/src/MockOpenIdProvider/MockOpenIdProvider.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>c579ff6b-d0e2-4956-95ba-0ca29725d498</UserSecretsId>
@@ -16,21 +16,18 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="DotNetEnv" Version="3.1.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.4">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.6">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="9.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.6" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.2" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="9.0.4" />
-    <PackageReference Include="System.Text.Json" Version="9.0.9" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.6" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="EcAuth.IdpUtilities" Version="1.0.0" />
+    <PackageReference Include="EcAuth.IdpUtilities" Version="1.1.0" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Migrations\" />

--- a/tests/MockOpenIdProvider.Test/MockOpenIdProvider.Test.csproj
+++ b/tests/MockOpenIdProvider.Test/MockOpenIdProvider.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
@@ -14,7 +14,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.6" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Summary
- \`MockOpenIdProvider\` を .NET 10 に移行
- \`EcAuth.IdpUtilities\` 依存を \`2.0.0\` に更新（SemVer メジャーバージョンアップに追従）
- Dockerfile / GitHub Actions を 10.0 系に更新

> **依存関係**: 本 PR の CI を通過させるには、先に [EcAuth.IdpUtilities#2](https://github.com/EcAuth/EcAuth.IdpUtilities/pull/2) をマージし、\`v2.0.0\` タグで GitHub Packages に publish 済みである必要があります。

## 背景
.NET 9 の EOL が 2026-11-10 に迫っているため、LTS の .NET 10 へ先行移行する。IdpUtilities は TargetFramework 変更が破壊的変更に当たるため、参照側もメジャーバージョンアップに追従。

## Changes
- \`src/MockOpenIdProvider/MockOpenIdProvider.csproj\`
  - \`TargetFramework\`: \`net9.0\` → \`net10.0\`
  - \`Microsoft.EntityFrameworkCore.Design\` / \`SqlServer\`: \`9.0.x\` → \`10.0.6\`
  - \`Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore\`: \`9.0.9\` → \`10.0.6\`
  - \`System.Configuration.ConfigurationManager\`: \`9.0.4\` → \`10.0.6\`
  - \`Swashbuckle.AspNetCore\`: \`8.1.1\` → \`10.1.7\`
  - \`EcAuth.IdpUtilities\`: \`1.0.0\` → \`2.0.0\`
  - \`Microsoft.Extensions.Configuration\` / \`Microsoft.Extensions.Configuration.Json\` / \`System.Text.Json\` の PackageReference を削除（net10.0 の BCL に取り込まれたため NU1510）
- \`tests/MockOpenIdProvider.Test/MockOpenIdProvider.Test.csproj\`
  - \`TargetFramework\`: \`net9.0\` → \`net10.0\`
  - \`Microsoft.EntityFrameworkCore.InMemory\`: \`9.0.9\` → \`10.0.6\`
- \`src/MockOpenIdProvider/Dockerfile\`: \`sdk:9.0\` / \`aspnet:9.0\` → \`:10.0\`
- \`.github/workflows/{ci,e2e-tests,migrate}.yml\`: \`dotnet-version\` を \`10.0.x\` に更新

## Test plan
- [x] \`dotnet restore\` / \`build --configuration Release\` が成功（ローカル、IdpUtilities 2.0.0 をローカルフィードから restore して検証）
- [x] \`dotnet test\` が全て成功（16 テスト合格）
- [x] IdpUtilities 2.0.0 publish 後、CI の .NET Tests ワークフローが green
- [x] Playwright E2E テスト（\`.github/workflows/e2e-tests.yml\`）が green
- [x] dev 環境（Container App）へのデプロイ後に疎通確認
- [x] staging 環境へのデプロイ後に E2E 疎通確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)