### PR TITLE
chore: Dependabot で actions/* と docker/* を minor/patch グループ化

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,21 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    # 公式 actions/* と docker/* を種類ごとに 1 PR に集約
+    # major は breaking change の可能性があるため個別 PR を維持
+    groups:
+      actions-minor-patch:
+        patterns:
+          - "actions/*"
+        update-types:
+          - "minor"
+          - "patch"
+      docker-minor-patch:
+        patterns:
+          - "docker/*"
+        update-types:
+          - "minor"
+          - "patch"
 
   # .NET NuGet パッケージの自動更新
   - package-ecosystem: "nuget"


### PR DESCRIPTION
## 概要

[EcAuth.IdpUtilities PR #3 のレビューコメント](https://github.com/EcAuth/EcAuth.IdpUtilities/pull/3#discussion_r3115449461) と同じ方針を本リポにも適用。本リポは Docker ワークフローも持つため、`actions/*` に加えて `docker/*` も 2 つ目のグループとして追加する。

## 変更内容

```yaml
groups:
  actions-minor-patch:
    patterns:
      - "actions/*"
    update-types:
      - "minor"
      - "patch"
  docker-minor-patch:
    patterns:
      - "docker/*"
    update-types:
      - "minor"
      - "patch"
```

## 動機

- `actions/checkout` / `actions/setup-dotnet` / `actions/setup-node` / `actions/upload-artifact` が同週にリリースされた場合、現状は **4 PR** が立つ → 集約で **1 PR** に
- `docker/setup-buildx-action` / `docker/login-action` / `docker/metadata-action` / `docker/build-push-action` も同様（4 → 1）
- `open-pull-requests-limit: 5` 枠の節約
- **major update は個別 PR を維持** することで breaking change の見逃しを防ぐ

## 動作確認

- [ ] マージ後、Dependabot が次週 grouping された PR を出すことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)