### PR TITLE
chore: Dependabot の依存更新を group 化

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,21 +15,23 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
-    # 公式 actions/* と docker/* を種類ごとに 1 PR に集約
-    # major は breaking change の可能性があるため個別 PR を維持
+    # minor/patch と major の 2 PR に集約する。
+    # patterns を "*" にしているのは、公式 actions/* 以外のサードパーティ
+    # （docker/* anthropics/* pnpm/* azure/* 等）を取りこぼさないため。
+    # docker/* は major 更新が同時に来ることが多く（build-push/login/metadata/
+    # setup-buildx）、ベンダー別 group + minor/patch 限定では個別 PR に散る。
     groups:
-      actions-minor-patch:
+      github-actions-minor:
         patterns:
-          - "actions/*"
+          - "*"
         update-types:
           - "minor"
           - "patch"
-      docker-minor-patch:
+      github-actions-major:
         patterns:
-          - "docker/*"
+          - "*"
         update-types:
-          - "minor"
-          - "patch"
+          - "major"
 
   # .NET NuGet パッケージの自動更新
   - package-ecosystem: "nuget"
@@ -42,16 +44,43 @@ updates:
       day: "tuesday"
       time: "09:00"
       timezone: "Asia/Tokyo"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
     labels:
       - "dependencies"
       - "dotnet"
     commit-message:
       prefix: "chore"
       include: "scope"
-    # セキュリティアップデートは即座に作成
     allow:
       - dependency-type: "all"
+    # group を指定すると複数 directories の同一パッケージ更新が 1 PR に集約される
+    groups:
+      nuget-minor:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      nuget-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+    # .NET ランタイム同梱パッケージの major 更新は、.NET 本体のメジャー移行と
+    # 同時に IdpUtilities → MockIdP → EcAuth の順で進める必要があるため止める。
+    # 手順は EcAuthDocs の claude-repository-guide.md
+    # 「.NET メジャーバージョン移行の順序（標準手順）」を参照。
+    ignore:
+      - dependency-name: "System.Text.Json"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "Microsoft.EntityFrameworkCore*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "Microsoft.AspNetCore*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "Microsoft.Extensions*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "dotnet-ef"
+        update-types: ["version-update:semver-major"]
 
   # E2E Tests の npm パッケージの自動更新
   - package-ecosystem: "npm"
@@ -72,3 +101,15 @@ updates:
     # 開発依存関係も含める
     allow:
       - dependency-type: "all"
+    groups:
+      npm-minor:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      npm-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"


### PR DESCRIPTION
## 背景

EcAuth 系リポジトリ全体で Dependabot PR が **52 件**滞留しており、うちこのリポジトリが **8 件**。

既存 group はベンダー別（`actions/*` / `docker/*`）かつ minor/patch 限定だったため、**同時に来た `docker/*` の major 4 件が全て group 対象外**になっていた。

| PR | 更新 |
|---|---|
| #49 | docker/login-action 3.7.0 → 4.1.0 |
| #50 | docker/build-push-action 6.19.2 → 7.1.0 |
| #52 | docker/setup-buildx-action 3.12.0 → 4.0.0 |
| #53 | docker/metadata-action 5.10.0 → 6.0.0 |

Docker の公式 actions はメジャーが揃って上がるため、minor/patch 限定の group とは相性が悪い。

## 変更内容

### 1. group を minor/patch と major の 2 本に集約

全エコシステム（github-actions / nuget / npm）で `patterns: ["*"]` を使い、必ずどちらかの group に入るようにした。上記 docker/* 4 件は `github-actions-major` の 1 PR に、#51（pnpm/action-setup 4→6）も同じくまとまる。

nuget は 3 つの `directories` を指定しているが、group 指定により同一パッケージ更新は 1 PR に集約される。

### 2. .NET ランタイム同梱パッケージの major 更新を `ignore` に追加

.NET 本体のメジャー移行は CLAUDE.md「.NET メジャーバージョン移行の順序（標準手順）」に沿って IdpUtilities → MockIdP → EcAuth の順で進める必要があるため、個別の追従 PR は止める。

**patch/minor は従来どおり通す。** バージョン範囲ではなく `update-types: ["version-update:semver-major"]` で指定しているのはこのため（EcAuth 側では前者の書き方で 10.x 内の更新まで止まっていた）。

## 検証

- [x] YAML パース（`yaml.safe_load`）
- [x] 指定した全 `directories`（`/` `/src/MockOpenIdProvider` `/tests/MockOpenIdProvider.Test` `/e2e-tests`）に対応する manifest が実在することを確認
- [x] 行末空白なし / LF 改行
- [ ] **Dependabot 設定の妥当性はサーバー側でしか検証できない**（未検証）。マージ後に Insights → Dependency graph → Dependabot でエラーが出ていないことを確認する

## マージ後の作業

既存のオープン PR は group 再編で置き換わるが、Dependabot が自動クローズしない場合がある。残存分を手動クローズし、`@dependabot recreate` または次回スケジュール実行（月=actions / 火=nuget / 水=npm、09:00 JST）で group PR を作らせる。

## 関連

EcAuth 系 10 リポジトリ横断で同じテンプレートを適用する PR の 1 本。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 依存関係の更新を、メジャー更新とマイナー・パッチ更新に分けて整理するよう改善しました。
  * 更新対象を適切にグループ化し、レビューや対応状況を確認しやすくしました。
  * 自動生成される更新リクエスト数を見直し、保守作業の負担を軽減しました。
  * 一部の.NET関連パッケージについて、不要なメジャー更新を抑制しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->